### PR TITLE
Add gravity-based grid deformation

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,17 +1,21 @@
 from space_time_grid import SpaceTimeGrid
 from grid_visualizer import visualize_grid
 
-def main():
-    # Create a grid for visualization
-    grid = SpaceTimeGrid(x_size=20, y_size=20, z_size=20, w_size=5, t_size=10, resolution=0.1)
-    
-    # Visualize the grid
-    visualize_grid(grid)
 
-if __name__ == "__main__":
+def main():
     print("Starting main")
-    grid = SpaceTimeGrid(x_size=20, y_size=20, z_size=20, w_size=5, t_size=10, resolution=0.1)
+    grid = SpaceTimeGrid(
+        x_size=20,
+        y_size=20,
+        z_size=20,
+        w_size=5,
+        t_size=10,
+        resolution=0.1,
+    )
     print("Grid created, calling visualize_grid")
     visualize_grid(grid)
     print("visualize_grid finished")
+
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- enable curved grid lines by subdividing each line into multiple segments
- apply displacement per segment so gravity warps the grid toward objects
- render force overlays using the same segment-based curves

## Testing
- `python -m py_compile grid_visualizer.py`
- `python -m py_compile main.py`
- `python main.py` *(fails: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d30141230832a987c8b7749429060