### PR TITLE
Fix OpenGL grid rendering without glBegin

### DIFF
--- a/grid_visualizer.py
+++ b/grid_visualizer.py
@@ -361,6 +361,7 @@ class GridVisualizer(QOpenGLWidget):
                     force_name,
                 )
         else:
+            glBegin(GL_LINES)
             for i in range(self.grid_density):
                 for j in range(self.grid_density):
 
@@ -376,8 +377,7 @@ class GridVisualizer(QOpenGLWidget):
                     p6 = self._apply_force(QVector3D(i * step, j * step, 1), force_name)
                     glVertex3f(p5.x(), p5.y(), p5.z())
                     glVertex3f(p6.x(), p6.y(), p6.z())
-
-        glEnd()
+            glEnd()
 
 
 


### PR DESCRIPTION
## Summary
- correct 3D force grid rendering by wrapping vertex generation with `glBegin(GL_LINES)`/`glEnd`

## Testing
- `python -m py_compile grid_visualizer.py main.py space_object.py space_time_grid.py`
- `python main.py` *(fails: ImportError: libGL.so.1)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688fa0115048832aa617aa88a522b673