### PR TITLE
Support velocity in object settings and fix grid rendering

### DIFF
--- a/space_object.py
+++ b/space_object.py
@@ -3,8 +3,10 @@ import numpy as np
 from PyQt5.QtGui import QVector3D
 
 class SpaceObject:
-    def __init__(self, position, radius, color, mass=1.0):
+    def __init__(self, position, radius, color, mass=1.0, velocity=None):
         self.position = position
         self.radius = radius
         self.color = color
         self.mass = mass
+        # Store velocity as a QVector3D. Defaults to zero velocity.
+        self.velocity = velocity if velocity is not None else QVector3D(0.0, 0.0, 0.0)


### PR DESCRIPTION
## Summary
- correct 3D force grid rendering by wrapping vertex emission with `glBegin(GL_LINES)`/`glEnd`
- add velocity attribute to space objects and propagate through the visualizer
- expose velocity components in the object settings dialog

## Testing
- `python -m py_compile grid_visualizer.py main.py space_object.py space_time_grid.py`
- `python main.py` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_688fa0115048832aa617aa88a522b673